### PR TITLE
Clarified the glue path is related to a package

### DIFF
--- a/content/docs/guides/10-minute-tutorial.md
+++ b/content/docs/guides/10-minute-tutorial.md
@@ -147,7 +147,7 @@ task cucumber() {
 }
 ```
 Note that you also need to add the necessary dependencies/configurations to `build.gradle` depending on which version of Gradle you are using.
-See the [Build Tools](/docs/tools/java/#gradle) section.
+See the [Build Tools](/docs/tools/java/#gradle) section. If you follow this guide be sure to set your `--glue` path to `hellocucumber` for this tutorial.
 
 If you have not already, open the project in IntelliJ IDEA:
 


### PR DESCRIPTION
The build tools page suggests settings the glue path to be `gradle.cucumber` which for a noob made me think gradle.cucumber' was a special gradle file